### PR TITLE
Add formkeys for client verification

### DIFF
--- a/classes/user.py
+++ b/classes/user.py
@@ -43,6 +43,8 @@ class User(Base):
         _formkey = hash(_formkey)
         return _formkey
 
+    def validate_formkey(self, formkey) -> bool:
+        return validate_hash(formkey, self.formkey)
 
     @property
     def is_banned(self):

--- a/classes/user.py
+++ b/classes/user.py
@@ -1,39 +1,52 @@
 from sqlalchemy import *
 from sqlalchemy.orm import relationship
 from __main__ import Base
+from flask import session
 from helpers.hash import *
 import time
+import secrets
 
 class User(Base):
-	__tablename__ = "Users"
+    __tablename__ = "Users"
 
-	id = Column(Integer, Sequence('Users_id_seq'), primary_key = True)
-	username = Column(String(50))
-	passhash = Column(String(750))
-	created_utc = Column(Integer)
-	creation_ip = Column(String(255))
-	is_admin = Column(Boolean, default = False)
-	banned_utc = Column(Integer, default = 0)
-	ban_expires_utc = Column(Integer, default = 0)
-	banned_by_id = Column(Integer, ForeignKey('Users.id'))
-	deleted_utc = Column(Integer, default = 0)
+    id = Column(Integer, Sequence('Users_id_seq'), primary_key = True)
+    username = Column(String(50))
+    passhash = Column(String(750))
+    created_utc = Column(Integer)
+    creation_ip = Column(String(255))
+    is_admin = Column(Boolean, default = False)
+    banned_utc = Column(Integer, default = 0)
+    ban_expires_utc = Column(Integer, default = 0)
+    banned_by_id = Column(Integer, ForeignKey('Users.id'))
+    deleted_utc = Column(Integer, default = 0)
 
-	def __init__(self, **kwargs):
-		if 'created_utc' not in kwargs:
-			kwargs['created_utc'] = int(time.time())
+    def __init__(self, **kwargs):
+        if 'created_utc' not in kwargs:
+            kwargs['created_utc'] = int(time.time())
 
-		if 'password' in kwargs:
-			kwargs['passhash'] = hash_password(kwargs['password'])
-			kwargs.pop('password', None)
+        if 'password' in kwargs:
+            kwargs['passhash'] = hash_password(kwargs['password'])
+            kwargs.pop('password', None)
 
-		super().__init__(**kwargs)
+        super().__init__(**kwargs)
 
-	def __repr__(self):
-		return f"<User(id='{self.id}'; name='{self.username}')>"
+    def __repr__(self):
+        return f"<User(id='{self.id}'; name='{self.username}')>"
 
-	@property
-	def is_banned(self):
-		return self.banned_utc > 0
+    @property
+    def formkey(self):
+        if 'session_id' not in session:
+            session['session_id'] = secrets.token_hex(16)
 
-	def verify_password(self, password) -> bool:
-		return check_password(password, self.passhash)
+        _formkey = f"{self.id}#{session['session_id']}"
+
+        _formkey = hash(_formkey)
+        return _formkey
+
+
+    @property
+    def is_banned(self):
+        return self.banned_utc > 0
+
+    def verify_password(self, password) -> bool:
+        return check_password(password, self.passhash)

--- a/classes/user.py
+++ b/classes/user.py
@@ -44,7 +44,7 @@ class User(Base):
         return _formkey
 
     def validate_formkey(self, formkey) -> bool:
-        return validate_hash(formkey, self.formkey)
+        return formkey == self.formkey
 
     @property
     def is_banned(self):

--- a/helpers/hash.py
+++ b/helpers/hash.py
@@ -5,7 +5,7 @@ import hmac
 from os import environ
 
 def hash(input) -> str:
-	msg = bytes(input, 'utc-16')
+	msg = bytes(input, 'utf-16')
 
 	return hmac.new(bytes(environ.get('MASTER_KEY'), 'utf-16'),
 		msg,

--- a/helpers/wrappers.py
+++ b/helpers/wrappers.py
@@ -53,3 +53,17 @@ def admin_required(f):
         return resp
 
     return wrapper
+
+def validate_formkey(f):
+    @wraps(f)
+    def wrapper(*args, u, **kwargs):
+        formkey = request.form.get("formkey", "")
+
+        if not formkey:
+            abort(403)
+
+        if not u.validate_formkey(formkey):
+            abort(403)
+
+        return f(*args, u, **kwargs)
+    return wrapper

--- a/helpers/wrappers.py
+++ b/helpers/wrappers.py
@@ -65,5 +65,5 @@ def validate_formkey(f):
         if not u.validate_formkey(formkey):
             abort(403)
 
-        return f(*args, u, **kwargs)
+        return f(*args, u = u, **kwargs)
     return wrapper

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -6,6 +6,7 @@ from helpers.wrappers import *
 @app.post('/admin/remove/post/<int:pid>')
 @auth_required
 @admin_required
+@validate_formkey
 def admin_remove_post(pid, u):
     target = get_post(pid, graceful = False)
 
@@ -20,6 +21,7 @@ def admin_remove_post(pid, u):
 @app.post('/admin/remove/comment/<int:cid>')
 @auth_required
 @admin_required
+@validate_formkey
 def admin_remove_comment(cid, u):
     target = get_comment(cid, graceful = False)
 
@@ -34,6 +36,7 @@ def admin_remove_comment(cid, u):
 @app.post('/admin/ban/board/<int:bid>')
 @auth_required
 @admin_required
+@validate_formkey
 def admin_ban_board(bid, u):
     target = get_board_id(bid, graceful = False)
 
@@ -46,6 +49,7 @@ def admin_ban_board(bid, u):
 @app.post('/admin/approve/post/<int:pid>')
 @auth_required
 @admin_required
+@validate_formkey
 def admin_approve_post(pid, u):
     target = get_post(pid, graceful = False)
 
@@ -64,6 +68,7 @@ def admin_approve_post(pid, u):
 @app.post('/admin/approve/comment/<int:cid>')
 @auth_required
 @admin_required
+@validate_formkey
 def admin_approve_comment(cid, u):
     target = get_comment(cid, graceful = False)
 
@@ -82,6 +87,7 @@ def admin_approve_comment(cid, u):
 @app.post('/admin/unban/board/<int:bid>')
 @auth_required
 @admin_required
+@validate_formkey
 def admin_unban_board(bid, u):
     target = get_board_id(bid, graceful = False)
 

--- a/routes/boards.py
+++ b/routes/boards.py
@@ -34,6 +34,7 @@ def get_create_board(u):
 @app.post('/create_board')
 #@limiter.limit("1/3days")
 @auth_required
+@validate_formkey
 def post_create_board(u):
     name = request.form['name']
     desc = request.form['desc']

--- a/templates/board.html
+++ b/templates/board.html
@@ -21,10 +21,12 @@ Welcome to /{{ board.name }}/: {{ board.description }}!
     {% if board.is_banned %}
     <form action="/admin/unban/board/{{ board.id }}" method="post">
         <strong style="background-color: #fa8072;">[board banned{% if board.ban_reason %}: {{ board.ban_reason }}{% endif %}]</strong>
+        <input type="hidden" name="formkey" value="{{ u.formkey }}" />
         <input type="submit" value="Unban /{{ board.name }}/">
     </form>
     {% else %}
     <form action="/admin/ban/board/{{ board.id }}" method="post">
+        <input type="hidden" name="formkey" value="{{ u.formkey }}" />
         <input type="text" name="reason" placeholder="reason" />
         <input type="submit" value="Ban /{{ board.name }}/">
     </form>

--- a/templates/create.html
+++ b/templates/create.html
@@ -11,6 +11,7 @@
     <p style="color: red;">{{ error }}</p>
     {% endif %}
     <form action="/create_board" method="post">
+        <input type="hidden" name="formkey" value="{{ u.formkey }}" />
         <label for="name">Board name:</label><br />
         <input id="name" name="name" required maxlength="5" placeholder="board name (eg: sex)" /><br />
         <label for="desc">Board description:</label><br />

--- a/templates/post.html
+++ b/templates/post.html
@@ -18,10 +18,12 @@
 	{% if post.is_removed %}
 	<form action="/admin/approve/post/{{ post.id }}" method="post">
 		<strong>[removed{% if post.removal_reason %}: {{ post.removal_reason }}{% endif %}]</strong>
+        <input type="hidden" name="formkey" value="{{ u.formkey }}" />
 		<input type="submit" value="Approve" />
 	</form>
 	{% else %}
 	<form action="/admin/remove/post/{{ post.id }}" method="post">
+        <input type="hidden" name="formkey" value="{{ u.formkey }}" />
 		<input type="text" name="reason" placeholder="reason" />
 		<input type="submit" value="Remove thread" />
 	</form>
@@ -47,10 +49,12 @@
 		{% if c.is_removed %}
 		<form action="/admin/approve/comment/{{ c.id }}" method="post">
 			<strong>[removed{% if c.removal_reason %}: {{ c.removal_reason }}{% endif %}]</strong>
+            <input type="hidden" name="formkey" value="{{ u.formkey }}" />
 			<input type="submit" value="Approve" />
 		</form>
 		{% else %}
 		<form action="/admin/remove/comment/{{ c.id }}" method="post">
+            <input type="hidden" name="formkey" value="{{ u.formkey }}" />
 			<input type="text" name="reason" placeholder="reason" />
 			<input type="submit" value="Remove comment" />
 		</form>


### PR DESCRIPTION
Adds a `formkey` property to accounts that's used to verify requests are from a trusted source (only the website itself for now). Should prevent unauthorized 3rd party scripts from accessing functions such as board creation.

For now, only the board creation and admin functions require a formkey; the submit endpoints remain accessible to everyone, and the rate limit should take care of spam scripts.